### PR TITLE
feat: Implement hotel search and room display enhancements

### DIFF
--- a/backend/src/controllers/Room/typeDefs.ts
+++ b/backend/src/controllers/Room/typeDefs.ts
@@ -37,6 +37,7 @@ export const roomTypeDef = gql`
     overlapping check‑in/check‑out dates for that room.  Both
     parameters are required and should be ISO formatted dates.
     """
-    availableRooms(hotelId: ID!, checkIn: Date!, checkOut: Date!): [Room!]!
+    availableRooms(hotelId: ID!, checkIn: Date!, checkOut: Date!, adults: Int!, children: Int!): [Room!]!
+    availableRoomsCount(hotelId: ID!, checkIn: Date!, checkOut: Date!, adults: Int!, children: Int!): Int!
   }
 `;

--- a/frontend/app/hotel/search/page.tsx
+++ b/frontend/app/hotel/search/page.tsx
@@ -52,17 +52,13 @@ export default function HotelSearchPage() {
       alert("Check‑out date must be after check‑in date");
       return;
     }
-    const booking = {
+    const searchParams = new URLSearchParams({
       checkIn,
       checkOut,
-      adults,
-      children,
-      guests: adults + children,
-    };
-    if (typeof window !== "undefined") {
-      localStorage.setItem("booking", JSON.stringify(booking));
-    }
-    router.push("/hotel/rooms");
+      adults: adults.toString(),
+      children: children.toString(),
+    });
+    router.push(`/hotel/rooms?${searchParams.toString()}`);
   };
 
   return (


### PR DESCRIPTION
This commit introduces several improvements to the hotel search and room display functionality.

Backend:
- The `availableRooms` GraphQL query now accepts `adults` and `children` parameters to filter rooms by capacity.
- A new `availableRoomsCount` query has been added to get the total number of available rooms.

Frontend:
- The hotel search page (`/hotel/search`) now passes search parameters (check-in, check-out, adults, children) as URL query parameters instead of using localStorage.
- The hotel rooms page (`/hotel/rooms`) has been enhanced with a new UI that includes:
  - Filter tabs for 'Hotels', 'Experiences', 'Hébergements', and 'Aventures'.
  - Sub-filters for 'Boutique', 'Luxe', 'Familial', and 'Romantique' under the 'Hotels' tab.
  - A "Chambres disponibles" title.
  - Pagination to display 4 rooms at a time.
  - A display of the total number of available rooms.