### PR TITLE
fix: Correct GraphQL syntax and add tables management page

### DIFF
--- a/backend/src/controllers/Business/resolvers.ts
+++ b/backend/src/controllers/Business/resolvers.ts
@@ -22,7 +22,7 @@ interface UpdateRestaurantInput {
   settings?: {
     horaires?: { ouverture: string; fermeture: string }[];
     capaciteTotale?: number;
-    tables?: { '2'?: number; '4'?: number; '6'?: number; '8'?: number };
+    tables?: { size2?: number; size4?: number; size6?: number; size8?: number };
     frequenceCreneauxMinutes?: number;
     maxReservationsParCreneau?: number;
   };
@@ -104,7 +104,7 @@ export const businessResolvers = {
     ) => {
       if (input.settings && input.settings.tables) {
         const tables = input.settings.tables;
-        const capaciteTheorique = (tables['2'] || 0) * 2 + (tables['4'] || 0) * 4 + (tables['6'] || 0) * 6 + (tables['8'] || 0) * 8;
+        const capaciteTheorique = (tables.size2 || 0) * 2 + (tables.size4 || 0) * 4 + (tables.size6 || 0) * 6 + (tables.size8 || 0) * 8;
         input.settings['capaciteTheorique'] = capaciteTheorique;
       }
       return RestaurantModel.findByIdAndUpdate(id, input, { new: true });

--- a/backend/src/controllers/Business/typeDefs.ts
+++ b/backend/src/controllers/Business/typeDefs.ts
@@ -113,10 +113,10 @@ export const businessTypeDef = gql`
   }
 
   type Tables {
-    "2": Int
-    "4": Int
-    "6": Int
-    "8": Int
+    size2: Int
+    size4: Int
+    size6: Int
+    size8: Int
   }
 
   input RestaurantSettingsInput {
@@ -140,10 +140,10 @@ export const businessTypeDef = gql`
   }
 
   input TablesInput {
-    "2": Int
-    "4": Int
-    "6": Int
-    "8": Int
+    size2: Int
+    size4: Int
+    size6: Int
+    size8: Int
   }
 
   type SalonSettings {

--- a/backend/src/models/RestaurantModel.ts
+++ b/backend/src/models/RestaurantModel.ts
@@ -38,7 +38,7 @@ interface RestaurantDocument extends Document {
     cancellationHours: number;
     horaires: { ouverture: string; fermeture: string }[];
     capaciteTotale: number;
-    tables: { '2': number; '4': number; '6': number; '8': number };
+    tables: { size2: number; size4: number; size6: number; size8: number };
     frequenceCreneauxMinutes: number;
     maxReservationsParCreneau: number;
     capaciteTheorique: number;
@@ -89,10 +89,10 @@ const restaurantSchema = new Schema<RestaurantDocument>({
     }],
     capaciteTotale: { type: Number, default: 0 },
     tables: {
-      '2': { type: Number, default: 0 },
-      '4': { type: Number, default: 0 },
-      '6': { type: Number, default: 0 },
-      '8': { type: Number, default: 0 }
+      size2: { type: Number, default: 0 },
+      size4: { type: Number, default: 0 },
+      size6: { type: Number, default: 0 },
+      size8: { type: Number, default: 0 }
     },
     frequenceCreneauxMinutes: { type: Number, default: 30 },
     maxReservationsParCreneau: { type: Number, default: 10 },

--- a/frontend/app/restaurant/dashboard/tables-disponibilites/page.tsx
+++ b/frontend/app/restaurant/dashboard/tables-disponibilites/page.tsx
@@ -24,10 +24,10 @@ const GET_RESTAURANT_SETTINGS = gql`
         }
         capaciteTotale
         tables {
-          "2"
-          "4"
-          "6"
-          "8"
+          size2
+          size4
+          size6
+          size8
         }
         frequenceCreneauxMinutes
         maxReservationsParCreneau
@@ -53,10 +53,10 @@ const formSchema = z.object({
   ).min(1, "Au moins une plage horaire est requise."),
   capaciteTotale: z.coerce.number().positive("La capacité totale doit être un nombre positif."),
   tables: z.object({
-    '2': z.coerce.number().min(0),
-    '4': z.coerce.number().min(0),
-    '6': z.coerce.number().min(0),
-    '8': z.coerce.number().min(0),
+    size2: z.coerce.number().min(0),
+    size4: z.coerce.number().min(0),
+    size6: z.coerce.number().min(0),
+    size8: z.coerce.number().min(0),
   }),
   frequenceCreneauxMinutes: z.coerce.number().positive("La fréquence doit être un nombre positif."),
   maxReservationsParCreneau: z.coerce.number().positive("La limite doit être un nombre positif."),
@@ -84,7 +84,7 @@ export default function TablesDisponibilitesPage() {
         { ouverture: "", fermeture: "" },
       ],
       capaciteTotale: 0,
-      tables: { '2': 0, '4': 0, '6': 0, '8': 0 },
+      tables: { size2: 0, size4: 0, size6: 0, size8: 0 },
       frequenceCreneauxMinutes: 0,
       maxReservationsParCreneau: 0,
     },
@@ -120,7 +120,7 @@ export default function TablesDisponibilitesPage() {
         form.reset({
             horaires: settings.horaires.length ? settings.horaires : [{ ouverture: "", fermeture: "" }, { ouverture: "", fermeture: "" }],
             capaciteTotale: settings.capaciteTotale || 0,
-            tables: settings.tables || { '2': 0, '4': 0, '6': 0, '8': 0 },
+            tables: settings.tables || { size2: 0, size4: 0, size6: 0, size8: 0 },
             frequenceCreneauxMinutes: settings.frequenceCreneauxMinutes || 0,
             maxReservationsParCreneau: settings.maxReservationsParCreneau || 0,
         });
@@ -134,10 +134,10 @@ export default function TablesDisponibilitesPage() {
   const watchCapaciteTotale = form.watch("capaciteTotale");
 
   const capaciteTheorique =
-    (watchTables['2'] || 0) * 2 +
-    (watchTables['4'] || 0) * 4 +
-    (watchTables['6'] || 0) * 6 +
-    (watchTables['8'] || 0) * 8;
+    (watchTables.size2 || 0) * 2 +
+    (watchTables.size4 || 0) * 4 +
+    (watchTables.size6 || 0) * 6 +
+    (watchTables.size8 || 0) * 8;
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     if (!restaurantId) return;
@@ -255,7 +255,7 @@ export default function TablesDisponibilitesPage() {
             <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <FormField
                     control={form.control}
-                    name="tables.2"
+                    name="tables.size2"
                     render={({ field }) => (
                         <FormItem>
                             <FormLabel>Tables de 2 personnes</FormLabel>
@@ -268,7 +268,7 @@ export default function TablesDisponibilitesPage() {
                 />
                 <FormField
                     control={form.control}
-                    name="tables.4"
+                    name="tables.size4"
                     render={({ field }) => (
                         <FormItem>
                             <FormLabel>Tables de 4 personnes</FormLabel>
@@ -281,7 +281,7 @@ export default function TablesDisponibilitesPage() {
                 />
                 <FormField
                     control={form.control}
-                    name="tables.6"
+                    name="tables.size6"
                     render={({ field }) => (
                         <FormItem>
                             <FormLabel>Tables de 6 personnes</FormLabel>
@@ -294,7 +294,7 @@ export default function TablesDisponibilitesPage() {
                 />
                 <FormField
                     control={form.control}
-                    name="tables.8"
+                    name="tables.size8"
                     render={({ field }) => (
                         <FormItem>
                             <FormLabel>Tables de 8 personnes</FormLabel>


### PR DESCRIPTION
This commit addresses a GraphQL syntax error and completes the implementation of the 'Gestion des tables et des disponibilités' page.

**Bug Fix:**
- Corrected a GraphQL syntax error in `backend/src/controllers/Business/typeDefs.ts` where numbers were used as field names in the `Tables` and `TablesInput` types. The field names have been changed to valid identifiers (e.g., `size2`).
- Updated the `RestaurantModel` and the `updateRestaurant` resolver to use the new field names.
- Updated the frontend page to use the new field names in the form and GraphQL queries.

**New Feature:**
- Completed the implementation of the 'Gestion des tables et des disponibilités' admin page.
- The backend model and API have been extended to support the new settings.
- The frontend page has been created with the full UI and form logic as specified.

**Next Steps & Blockers:**
The implementation of the feature and the bug fix are complete. The final step was to perform end-to-end testing and visual verification.

I was unable to complete this final step due to persistent issues starting the development servers. I encountered repeated errors when trying to run `npm run dev` in the `frontend` and `backend` subdirectories, which prevented me from verifying the full functionality in a live environment.