### PR TITLE
fix: Align GraphQL schema with frontend and data model

### DIFF
--- a/backend/src/controllers/Business/typeDefs.ts
+++ b/backend/src/controllers/Business/typeDefs.ts
@@ -108,10 +108,10 @@ export const businessTypeDef = gql`
   }
 
   type Tables {
-    seats2: Int
-    seats4: Int
-    seats6: Int
-    seats8: Int
+    size2: Int
+    size4: Int
+    size6: Int
+    size8: Int
   }
 
   input RestaurantSettingsInput {
@@ -135,10 +135,10 @@ export const businessTypeDef = gql`
   }
 
   input TablesInput {
-    seats2: Int
-    seats4: Int
-    seats6: Int
-    seats8: Int
+    size2: Int
+    size4: Int
+    size6: Int
+    size8: Int
   }
 
   type SalonSettings {


### PR DESCRIPTION
This commit fixes a bug where the `updateRestaurant` mutation was failing due to a mismatch in field names for the table capacity inputs.

The GraphQL schema (`business/typeDefs.ts`) was using `seats2`, `seats4`, etc., for the `Tables` and `TablesInput` types, while the frontend and the Mongoose data model were using `size2`, `size4`, etc. This caused a `BAD_USER_INPUT` error at the GraphQL layer.

The fix renames the fields in the GraphQL schema to `size2`, `size4`, etc., to align them with the rest of the application, resolving the mutation error.