### PR TITLE
fix: Correct date filtering in restaurant dashboard

### DIFF
--- a/backend/src/controllers/dashboard/resolvers.ts
+++ b/backend/src/controllers/dashboard/resolvers.ts
@@ -48,8 +48,8 @@ export const dashboardResolvers = {
     },
 
     dashboardCalendar: async (_, { restaurantId, month }) => {
-      const start = moment(month).startOf('month').toDate();
-      const end = moment(month).endOf('month').toDate();
+      const start = moment.utc(month).startOf('month').toDate();
+      const end = moment.utc(month).endOf('month').toDate();
 
       const reservations = await ReservationModel.find({
         businessId: restaurantId,
@@ -58,7 +58,7 @@ export const dashboardResolvers = {
       }).select('date');
 
       const heatMap = reservations.reduce((acc, r) => {
-        const dateStr = moment(r.date).format('YYYY-MM-DD');
+        const dateStr = moment.utc(r.date).format('YYYY-MM-DD');
         acc[dateStr] = (acc[dateStr] || 0) + 1;
         return acc;
       }, {});
@@ -70,8 +70,8 @@ export const dashboardResolvers = {
     },
 
     reservationsByDate: async (_, { restaurantId, date }) => {
-      const targetDate = moment(date).startOf('day').toDate();
-      const nextDay = moment(targetDate).add(1, 'days').toDate();
+      const targetDate = moment.utc(date).startOf('day').toDate();
+      const nextDay = moment.utc(targetDate).add(1, 'days').toDate();
 
       const reservations = await ReservationModel.find({
         businessId: restaurantId,
@@ -81,7 +81,7 @@ export const dashboardResolvers = {
 
       return reservations.map(r => ({
         id: r._id.toString(),
-        date: moment(r.date).format('YYYY-MM-DD'),
+        date: moment.utc(r.date).format('YYYY-MM-DD'),
         heure: r.time,
         restaurant: r.businessId ? (r.businessId as any).name : 'N/A',
         personnes: r.partySize,

--- a/frontend/app/restaurant/dashboard/overview/page.tsx
+++ b/frontend/app/restaurant/dashboard/overview/page.tsx
@@ -117,7 +117,7 @@ export default function RestaurantOverviewPage() {
   const { data: reservationsData, loading: reservationsLoading, refetch: refetchReservations } = useQuery(GET_RESERVATIONS_BY_DATE, {
     variables: {
         restaurantId,
-        date: moment(selectedDate).format("YYYY-MM-DD"),
+        date: moment.utc(selectedDate).format("YYYY-MM-DD"),
     },
     skip: !restaurantId || !selectedDate,
   });
@@ -201,7 +201,7 @@ export default function RestaurantOverviewPage() {
   }
 
   function CustomDayContent(props: DayContentProps) {
-    const isBooked = bookedDays.some(d => moment(d).isSame(props.date, 'day'));
+    const isBooked = bookedDays.some(d => moment.utc(d).isSame(moment.utc(props.date), 'day'));
     return (
       <div className="relative">
         <DayContent {...props} />
@@ -285,7 +285,7 @@ export default function RestaurantOverviewPage() {
               ) : (
                 paginatedReservations.map((res: any) => (
                   <TableRow key={res.id}>
-                    <TableCell className="font-medium">{moment(res.date).format("DD/MM/YYYY")}</TableCell>
+                    <TableCell className="font-medium">{moment.utc(res.date).format("DD/MM/YYYY")}</TableCell>
                     <TableCell>{res.heure}</TableCell>
                     <TableCell>{res.restaurant}</TableCell>
                     <TableCell>{res.personnes}</TableCell>


### PR DESCRIPTION
This commit fixes a bug where reservations were not being displayed correctly in the restaurant dashboard when a date was selected.

The issue was caused by inconsistent timezone handling between the frontend and the backend. Dates were being created and formatted in the local timezone, which led to mismatches when your timezone was different from the server's.

The fix involves the following changes:
- The `dashboardCalendar` and `reservationsByDate` GraphQL resolvers have been updated to use UTC dates.
- The restaurant dashboard overview page on the frontend has been updated to use UTC dates for all date comparisons and formatting.