### PR TITLE
fix: Use clientId for reservation filtering

### DIFF
--- a/backend/src/controllers/Business/resolvers.ts
+++ b/backend/src/controllers/Business/resolvers.ts
@@ -205,16 +205,19 @@ export const businessResolvers = {
       { input }
     ) => {
       const { restaurantId, ...reservationData } = input;
+      const restaurant = await RestaurantModel.findById(restaurantId);
+      if (!restaurant) {
+        throw new GraphQLError('Restaurant not found.');
+      }
       const reservation = new ReservationModel({
         ...reservationData,
-        businessId: restaurantId,
+        businessId: restaurant.clientId,
         businessType: "restaurant",
         partySize: input.personnes,
         time: input.heure,
-        status: "confirmed", // As per new flow, confirmation is the final step
+        status: "confirmed",
       });
       await reservation.save();
-      // Assuming the Reservation loader can resolve the fields
       return reservation;
     },
 
@@ -223,11 +226,13 @@ export const businessResolvers = {
       { input }
     ) => {
       const { restaurantId, ...privatisationData } = input;
-      // This is a simplified version. A real implementation would need to
-      // block the capacity for the given time slot.
+      const restaurant = await RestaurantModel.findById(restaurantId);
+      if (!restaurant) {
+        throw new GraphQLError('Restaurant not found.');
+      }
       const reservation = new ReservationModel({
         ...privatisationData,
-        businessId: restaurantId,
+        businessId: restaurant.clientId,
         businessType: "restaurant",
         partySize: input.personnes,
         time: input.heure,

--- a/backend/src/controllers/dashboard/resolvers.ts
+++ b/backend/src/controllers/dashboard/resolvers.ts
@@ -15,7 +15,7 @@ export const dashboardResolvers = {
       const endDate = to ? moment(to) : moment().endOf('month');
 
       const reservations = await ReservationModel.find({
-        businessId: restaurantId,
+        businessId: restaurant.clientId,
         businessType: 'restaurant',
         date: { $gte: startDate.toDate(), $lte: endDate.toDate() },
       });
@@ -48,11 +48,15 @@ export const dashboardResolvers = {
     },
 
     dashboardCalendar: async (_, { restaurantId, month }) => {
+      const restaurant = await RestaurantModel.findById(restaurantId);
+      if (!restaurant) {
+        throw new GraphQLError('Restaurant not found.');
+      }
       const start = moment.utc(month).startOf('month').toDate();
       const end = moment.utc(month).endOf('month').toDate();
 
       const reservations = await ReservationModel.find({
-        businessId: restaurantId,
+        businessId: restaurant.clientId,
         businessType: 'restaurant',
         date: { $gte: start, $lte: end },
       }).select('date');
@@ -70,11 +74,15 @@ export const dashboardResolvers = {
     },
 
     reservationsByDate: async (_, { restaurantId, date }) => {
+      const restaurant = await RestaurantModel.findById(restaurantId);
+      if (!restaurant) {
+        throw new GraphQLError('Restaurant not found.');
+      }
       const targetDate = moment.utc(date).startOf('day').toDate();
       const nextDay = moment.utc(targetDate).add(1, 'days').toDate();
 
       const reservations = await ReservationModel.find({
-        businessId: restaurantId,
+        businessId: restaurant.clientId,
         businessType: 'restaurant',
         date: { $gte: targetDate, $lt: nextDay },
       }).populate('businessId');
@@ -118,7 +126,7 @@ export const dashboardResolvers = {
       const endOfDay = moment.utc(date).endOf('day').toDate();
 
       const reservations = await ReservationModel.find({
-        businessId: restaurantId,
+        businessId: restaurant.clientId,
         businessType: 'restaurant',
         date: { $gte: startOfDay, $lt: endOfDay },
         status: { $in: ['confirmed', 'pending'] } // Consider pending as well

--- a/backend/src/controllers/inputs.ts
+++ b/backend/src/controllers/inputs.ts
@@ -19,6 +19,7 @@ export const inputs = gql`
   }
 
   input RestaurantInput {
+    clientId: ID!
     name: String!
     description: String
     address: AddressInput

--- a/backend/src/models/RestaurantModel.ts
+++ b/backend/src/models/RestaurantModel.ts
@@ -14,6 +14,7 @@ interface Policy extends Document {
 }
 
 interface RestaurantDocument extends Document {
+  clientId: mongoose.Types.ObjectId;
   name: string;
   description: string;
   address: {
@@ -57,6 +58,11 @@ interface RestaurantDocument extends Document {
 }
 
 const restaurantSchema = new Schema<RestaurantDocument>({
+  clientId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Client',
+    required: true,
+  },
   name: {
     type: String,
     required: true,


### PR DESCRIPTION
This commit fixes a bug where reservations were not being correctly filtered in the dashboard and other parts of the application.

The issue was that `restaurantId` was being used to filter the `businessId` of a reservation, but the `businessId` is actually a `clientId`.

The fix involves the following changes:
- Added a `clientId` field to the `RestaurantModel` to create a link between a restaurant and a client.
- Updated the `createRestaurant` mutation to save the `clientId`.
- Updated the `createReservationV2` and `createPrivatisationV2` mutations to use the `clientId` from the restaurant as the `businessId` for the reservation.
- Updated the `reservationsByDate`, `dashboardMetrics`, `dashboardCalendar`, and `availability` resolvers to correctly use the `clientId` for filtering reservations.